### PR TITLE
Enable users to use ReflectionProperty and other classes.

### DIFF
--- a/src/DocBlockReader/Reader.php
+++ b/src/DocBlockReader/Reader.php
@@ -16,7 +16,7 @@ class Reader
 
 	public function __construct($class, $method, $reflectionClass = 'ReflectionMethod')
 	{
-	        $reflectionClass = '\\' . $reflectionClass;
+	    $reflectionClass = '\\' . $reflectionClass;
 		$reflection = new $reflectionClass($class, $method);
 		$this->rawDocBlock = $reflection->getDocComment();
 		$this->parameters = array();


### PR DESCRIPTION
Example:

```
$reader = new \DocBlockReader\Reader(__CLASS__, $property, 'ReflectionProperty');
```
